### PR TITLE
Asset hints and compliance updates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,16 +87,20 @@ it will be flattened.
    msg.set_send_to_syslog(True, only_syslog=True)
    msg.send()
 
-Compliance and vulnerability events are submitted by setting the log
+Compliance events (MozDefCompliance()) are sent the same way as
+generic events. Typically details and tags will be set. Details must
+adhere to the compliance event format or validation will fail.
+
+Vulnerability events are submitted by setting the log
 attribute of the object to a dict representing the event. This dict is
 converted in it's entirety to the event. The following is an example for
-compliance events.
+vulnerability events.
 
 .. code::
 
    import mozdef_client
-   msg = mozdef_client.MozDefCompliance('https://127.0.0.1:8443/compliance')
-   msg.log = compliance_msg
+   msg = mozdef_client.MozDefVulnerability('https://127.0.0.1:8443/compliance')
+   msg.log = vuln_msg
    msg.send()
 
 Hint events operate like generic events, but set some default fields

--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,7 @@ to be added in the future.
 - Generic Events
 - Compliance Events
 - Vulnerability Events
+- Asset Hint Events
 
 This library was previously known as mozdef_lib, but was renamed for clarity.
 The previous version of the library can be found at `mozdef_lib`_.
@@ -96,6 +97,17 @@ compliance events.
    import mozdef_client
    msg = mozdef_client.MozDefCompliance('https://127.0.0.1:8443/compliance')
    msg.log = compliance_msg
+   msg.send()
+
+Hint events operate like generic events, but set some default fields
+for you.
+
+.. code::
+
+   import mozdef_client
+   msg = mozdef_client.MozDefAssetHint('https://127.0.0.1:8443/events')
+   msg.summary = 'new host detected'
+   msg.details = {'hostname': 'test'}
    msg.send()
 
 With generic event messages, the summary field is the only mandatory field

--- a/mozdef_client.py
+++ b/mozdef_client.py
@@ -296,18 +296,21 @@ class MozDefAssetHint(MozDefEvent):
 
 class MozDefCompliance(MozDefEvent):
     def validate_log(self):
+        if 'details' not in self._sendlog:
+            return False
+        t = self._sendlog['details']
         for k in ['target', 'policy', 'check', 'compliance', 'link',
             'utctimestamp']:
-            if k not in self.details.keys():
+            if k not in t.keys():
                 return False
         for k in ['level', 'name', 'url']:
-            if k not in self.details['policy'].keys():
+            if k not in t['policy'].keys():
                 return False
         for k in ['description', 'location', 'name', 'test']:
-            if k not in self.details['check'].keys():
+            if k not in t['check'].keys():
                 return False
         for k in ['type', 'value']:
-            if k not in self.details['check']['test'].keys():
+            if k not in t['check']['test'].keys():
                 return False
         return True
 


### PR DESCRIPTION
This change adds support for sending asset hints.

It also changes the way compliance events are sent (in MozDef they are now structured like a generic MozDef event).